### PR TITLE
README: Fix missing fonts

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,7 @@ A simple GUI to manage the users and passwords in .htpasswd files. Built with [L
 git clone https://github.com/iresults/HtpasswdManager.git;
 cd HtpasswdManager;
 composer install;
+ln -s vendor/fortawesome/font-awesome/fonts public/fonts;
 ```
 
 Set the path to the .htpasswd file and the names of the admin users in `.env`:


### PR DESCRIPTION
I had to run 
```
mkdir -p public/fonts/ && cp vendor/fortawesome/font-awesome/fonts/ public/fonts/
```
or
```
ln -s vendor/fortawesome/font-awesome/fonts public/fonts
```

in order to get the fonts served.

```
/var/www/html/HtpasswdManager# ls public/fonts/
FontAwesome.otf  fontawesome-webfont.eot  fontawesome-webfont.svg  fontawesome-webfont.ttf  fontawesome-webfont.woff
```

Maybe this should be mentioned in README.md?